### PR TITLE
Remove duplicate subparser definition

### DIFF
--- a/chc/cmdline/chkc
+++ b/chc/cmdline/chkc
@@ -1180,16 +1180,6 @@ def parse() -> argparse.Namespace:
         "--tgtpath", help="directory that holds the analysis results")
     cfile_membasetable.set_defaults(func=CT.cfile_membase_table)
 
-    # --- function table: membase
-    cfile_membasetable = cfilefntablesparsers.add_parser("memory-base")
-    cfile_membasetable.add_argument(
-        "filename", help="name of file analyzed ((<cpath/>)<cfilename>)")
-    cfile_membasetable.add_argument(
-        "function", help="name of function of interest")
-    cfile_membasetable.add_argument(
-        "--tgtpath", help="directory that holds the analysis results")
-    cfile_membasetable.set_defaults(func=CT.cfile_membase_table)
-
     # --- function table: memref
     cfile_memreftable = cfilefntablesparsers.add_parser("memory-reference")
     cfile_memreftable.add_argument(


### PR DESCRIPTION
This fixes the error
```
  File "CodeHawk-C/chc/cmdline/chkc", line 1420, in <module>
    args = parse()
           ^^^^^^^
  File "CodeHawk-C/chc/cmdline/chkc", line 1184, in parse
    cfile_membasetable = cfilefntablesparsers.add_parser("memory-base")
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/argparse.py", line 1219, in add_parser
    raise ArgumentError(self, _('conflicting subparser: %s') % name)
argparse.ArgumentError: argument {numerical,symbol,variable,xconstant,xpr,xpr-list,xpr-list-list,memory-base}: conflicting subparser: memory-base
```