### PR TITLE
APP: handle static initializers with local var refs

### DIFF
--- a/chc/app/CDictionary.py
+++ b/chc/app/CDictionary.py
@@ -711,7 +711,7 @@ class CDictionary(ABC):
             self, lval: CLval, subst: Dict[int, CExp] = {}, fid: int = -1) -> int:
         args: List[int] = [
             self.index_lhost(lval.lhost, subst=subst, fid=fid),
-            self.index_offset(lval.offset)]
+            self.index_offset(lval.offset, fid=fid)]
         return self.mk_lval_index(lval.tags, args)
 
     def index_offset(self, o: COffset, fid: int = -1) -> int:

--- a/chc/app/CFileGlobals.py
+++ b/chc/app/CFileGlobals.py
@@ -370,12 +370,12 @@ class CFileGlobals:
     def global_varinfo_vids(self) -> Dict[int, "CVarInfo"]:
         if self._globalvarinfovids is None:
             self._globalvarinfovids = {}
+            for (vid, gfun) in self.gfunctions.items():
+                self._globalvarinfovids[vid] = gfun.varinfo
             for (vid, vardef) in self.gvardefs.items():
                 self._globalvarinfovids[vid] = vardef.varinfo
             for (vid, vardecl) in self.gvardecls.items():
                 self._globalvarinfovids[vid] = vardecl.varinfo
-            for (vid, gfun) in self.gfunctions.items():
-                self._globalvarinfovids[vid] = gfun.varinfo
         return self._globalvarinfovids
 
     def get_global_varinfos(self) -> List["CVarInfo"]:

--- a/chc/app/CGlobalDictionary.py
+++ b/chc/app/CGlobalDictionary.py
@@ -73,7 +73,7 @@ class CGlobalDictionary(CDictionary):
     def decls(self) -> "CGlobalDeclarations":
         return self.capp.declarations
 
-    def index_compinfo_key(self, compinfo, fid):
+    def index_compinfo_key(self, compinfo, fid) -> int:
         chklogger.logger.info(
             "Index compinfo key %s for fid %d", compinfo.name, fid)
         return self.decls.index_compinfo_key(compinfo, fid)


### PR DESCRIPTION
Initializers of static variables must be constant expressions, according to the C standard. However, when located within a function they may still reference local variables, like so (from the file application):

```
file_private int
apprentice_compile(struct magic_set *ms, struct magic_map *map, const char *fn)
{
	static const size_t nm = sizeof(*map->nmagic) * MAGIC_SETS;
```

Static variables are treated like global variables by the analyzer, and thus they are, together with their initializers, indexed  at the global level. The local variable (or parameter in this case) is of course not available at the global level, and therefore indexing fails. The solution for now is to drop the initializer at the global level. This is not a problem as long as the value doesn't escape to other files, since the initializer will still be available in the local file analysis (as performed by the ocaml analyzer for each file individually).