### PR TITLE
JSON: add program context to proof obligations

### DIFF
--- a/chc/app/CContext.py
+++ b/chc/app/CContext.py
@@ -73,6 +73,9 @@ class CContextNode(CContextDictionaryRecord):
     def name(self) -> str:
         return self.tags[0]
 
+    def has_data_id(self) -> bool:
+        return len(self.args) > 0
+
     @property
     def data_id(self) -> int:
         if len(self.args) > 0:
@@ -80,6 +83,13 @@ class CContextNode(CContextDictionaryRecord):
         else:
             raise UF.CHCError(
                 "Context node " + self.name + " does not have a data-id")
+
+    def has_additional_info(self) -> bool:
+        return len(self.tags) > 1
+
+    @property
+    def info(self) -> List[str]:
+        return self.tags[1:]
 
     def __str__(self) -> str:
         if len(self.args) == 0:

--- a/chc/app/CHVersion.py
+++ b/chc/app/CHVersion.py
@@ -1,1 +1,1 @@
-chcversion: str = "0.2.0-2024-05-19"
+chcversion: str = "0.2.0-2024-11-04"


### PR DESCRIPTION
Adds program context to the json output of proof obligations.

The program context consists of a control-flow-graph (cfg) context and an expression (exp) context. The cfg context specifies the location of the proof obligation in the cfg as a sequence of nodes ordered inside out from the location of the target of the proof obligation. The exp context specifies the location of the (sub)expression of the target expression of the proof obligation, also inside out from the target expression.

Example: 
For the code
```
{
    ...
    if (...) {
       ...
       if (...) {
          if (...) {
             a[i] = ...
```
the proof obligation `initialized(i)` could have program context:
```
cfg: [ instr(0); stmt(6); if-then; stmt(5); if-then; stmt(4); if-then; stmt(2) ]
exp: [ index; var; lhs ]
```
the proof obligation `index-lower-bound(i)` would have the same cfg context, but exp context:
```
exp: [ var; lhs ]
```
because it is associated with `a[i]` rather than just `i` itself.

 