### PR TITLE
Switch github actions to run on ubuntu 22.04

### DIFF
--- a/.github/workflows/run_mypy.yaml
+++ b/.github/workflows/run_mypy.yaml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 jobs:
   run_mypy:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/run_pycodestyle.yaml
+++ b/.github/workflows/run_pycodestyle.yaml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 jobs:
   run_pycodestyle:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
the 20.04 runner was deprecated and removed:
https://github.com/actions/runner-images/issues/11101