### PR TITLE
CMD: Allow excluding files from analysis

### DIFF
--- a/chc/app/CApplication.py
+++ b/chc/app/CApplication.py
@@ -6,7 +6,7 @@
 #
 # Copyright (c) 2017-2020 Kestrel Technology LLC
 # Copyright (c) 2020-2022 Henny B. Sipma
-# Copyright (c) 2023-2024 Aarno Labs LLC
+# Copyright (c) 2023-2025 Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/chc/cmdline/c_project/cprojectutil.py
+++ b/chc/cmdline/c_project/cprojectutil.py
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2024  Aarno Labs, LLC
+# Copyright (c) 2024-2025  Aarno Labs, LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -170,6 +170,7 @@ def cproject_analyze_project(args: argparse.Namespace) -> NoReturn:
     loglevel: str = args.loglevel
     logfilename: Optional[str] = args.logfilename
     logfilemode: str = args.logfilemode
+    excludefiles: List[str] = args.exclude
 
     if not os.path.isdir(tgtpath):
         print_error(f"Target directory {tgtpath} not found")
@@ -193,7 +194,7 @@ def cproject_analyze_project(args: argparse.Namespace) -> NoReturn:
         exit(1)
 
     capp = CApplication(
-        projectpath, projectname, targetpath, contractpath)
+        projectpath, projectname, targetpath, contractpath, excludefiles=excludefiles)
 
     def save_xrefs(f: "CFile") -> None:
         capp.indexmanager.save_xrefs(
@@ -206,7 +207,7 @@ def cproject_analyze_project(args: argparse.Namespace) -> NoReturn:
     linker.save_global_compinfos()
 
     capp = CApplication(
-        projectpath, projectname, targetpath, contractpath)
+        projectpath, projectname, targetpath, contractpath, excludefiles=excludefiles)
 
     am = AnalysisManager(capp, verbose=True)
 

--- a/chc/cmdline/chkc
+++ b/chc/cmdline/chkc
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2023-2024  Aarno Labs, LLC
+# Copyright (c) 2023-2025  Aarno Labs, LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1350,6 +1350,9 @@ def parse() -> argparse.Namespace:
         choices=["a", "w"],
         default="a",
         help="file mode for log file: append (a, default), or write (w)")
+    cprojectanalyze.add_argument("-x", "--exclude", action='append',
+        help="Exclude file from analysis. To exclude multiple files, use "
+             "this option for each file, e.g. -x dir1/f1.c, -x dir2/f2.c")
     cprojectanalyze.set_defaults(func=P.cproject_analyze_project)
 
     # --- report


### PR DESCRIPTION
The functionality was already there in CApplication, this just exposes it 
as a command line parameter in `chkc c-project analyze`