### PR TITLE
JSON: fix serialization error due to SituatedMsg

### DIFF
--- a/chc/app/CHVersion.py
+++ b/chc/app/CHVersion.py
@@ -1,1 +1,1 @@
-chcversion: str = "0.2.0-2026-02-23"
+chcversion: str = "0.2.0-2026-02-26"

--- a/chc/cmdline/jsonresultutil.py
+++ b/chc/cmdline/jsonresultutil.py
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------------------------
 # The MIT License (MIT)
 #
-# Copyright (c) 2024  Aarno Labs LLC
+# Copyright (c) 2024-2026  Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -203,12 +203,12 @@ def ppo_to_json_result(po: "CFunctionPO") -> JSONResult:
     content["predicate"] = str(po.predicate)
     content["context"] = programcontext_to_json_result(po.context).content
     if po.is_closed:
-        content["expl"] = po.explanation
+        content["expl"] = po.explanation_txt
     else:
         if po.has_diagnostic():
-            content["argdiagnostics"] = po.diagnostic.argument_msgs
+            content["argdiagnostics"] = po.diagnostic.argument_msgs_txt
             content["keydiagnostics"] = po.diagnostic.keyword_msgs
-            content["msgdiagnostics"] = po.diagnostic.msgs
+            content["msgdiagnostics"] = po.diagnostic.msgs_txt
     return JSONResult("ppo", content, "ok")
 
 

--- a/chc/proof/CFunctionPO.py
+++ b/chc/proof/CFunctionPO.py
@@ -6,7 +6,7 @@
 #
 # Copyright (c) 2017-2020 Kestrel Technology LLC
 # Copyright (c) 2020-2022 Henny B. Sipma
-# Copyright (c) 2023-2024 Aarno Labs LLC
+# Copyright (c) 2023-2026 Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -184,6 +184,16 @@ class CFunctionPO:
     @property
     def explanation(self) -> Optional["SituatedMsg"]:
         return self._explanation
+
+    @property
+    def explanation_txt(self) -> Optional[str]:
+        """Returns the text of the explanation message without the additional
+        details."""
+
+        if self.explanation is not None:
+            return self.explanation.msg
+        else:
+            return None
 
     def has_explanation(self) -> bool:
         return self._explanation is not None

--- a/chc/proof/CProofDiagnostic.py
+++ b/chc/proof/CProofDiagnostic.py
@@ -6,7 +6,7 @@
 #
 # Copyright (c) 2017-2020 Kestrel Technology LLC
 # Copyright (c) 2020-2022 Henny B. Sipma
-# Copyright (c) 2023-2024 Aarno Labs LLC
+# Copyright (c) 2023-2026 Aarno Labs LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -149,6 +149,13 @@ class CProofDiagnostic:
         return self._msgs
 
     @property
+    def msgs_txt(self) -> List[str]:
+        """Returns the ext of the situated msgs without the additional
+        details."""
+
+        return [smsg.msg for smsg in self.msgs]
+
+    @property
     def argument_msgs(self) -> Dict[int, List[SituatedMsg]]:
         """Returns argument-specific diagnostic messages.
 
@@ -167,6 +174,16 @@ class CProofDiagnostic:
                                 SituatedMsg(self.cd, x) for x in n.findall("msg")]
                             self._amsgs[int(xargindex)] = msgs
         return self._amsgs
+
+    @property
+    def argument_msgs_txt(self) -> Dict[int, List[str]]:
+        """Returns the texts of the situated msgs without the additional
+        details."""
+
+        result: Dict[int, List[str]] = {}
+        for (index, smsgs) in self.argument_msgs.items():
+            result[index] = [smsg.msg for smsg in smsgs]
+        return result
 
     @property
     def keyword_msgs(self) -> Dict[str, List[str]]:


### PR DESCRIPTION
This pull request fixes the json serialization error that was introduced by the replacement of diagnostic message strings by a more structured message (SituatedMsg). The fix in the json serializer extracts the original (str) message from the SituatedMsg, thereby restoring the original json output that was produced before.

At some later time it may be worth it to revisit this serialization and include the other details from the SituatedMsg in the json output.